### PR TITLE
requirements.txt: add urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Paver==1.3.4
 selenium==3.141.0
 behave==1.2.6
 Appium-Python-Client==1.0.2
+urllib3==1.26.16


### PR DESCRIPTION
When running this repo it wasn't working correctly due to this [issue](https://stackoverflow.com/questions/76614392/getting-error-when-i-run-selenium-script-value-error-timeout-value-connect-was) 

This suggests to use the specific version of `urllib3` and this also works locally.